### PR TITLE
Increase min_filters in default benchmark

### DIFF
--- a/benchmark_config_default.yml
+++ b/benchmark_config_default.yml
@@ -3,7 +3,7 @@ data_path: "data/" #change to ABI directory
 parallel_processes: 35
 split_date: "2018-05-20"
 conv_net_parameters:
-  min_filters: 16
+  min_filters: 32
   use_dropout: 0
   dropout_alpha: 0.1
   verbose: 1

--- a/goes16ci/models.py
+++ b/goes16ci/models.py
@@ -5,7 +5,6 @@ from tensorflow.keras.models import Model, save_model
 from tensorflow.keras.optimizers import Adam, SGD
 import tensorflow.keras.backend as K
 from tensorflow.keras.callbacks import Callback
-from tensorflow.keras.utils import multi_gpu_model
 import numpy as np
 import pandas as pd
 from time import perf_counter

--- a/notebooks/plot_gpu_perf.ipynb
+++ b/notebooks/plot_gpu_perf.ipynb
@@ -326,6 +326,100 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 102,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(\"/glade/u/home/gwallach/holodec-ml/scripts/Gunther/data_cube.nc\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:                        (dim_0: 10000, dim_1: 178, dim_2: 118)\n",
+       "Dimensions without coordinates: dim_0, dim_1, dim_2\n",
+       "Data variables:\n",
+       "    __xarray_dataarray_variable__  (dim_0, dim_1, dim_2) float64 ..."
+      ]
+     },
+     "execution_count": 104,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 115,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.QuadMesh at 0x2b80f1691a20>"
+      ]
+     },
+     "execution_count": 115,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAQcElEQVR4nO3df6yeZX3H8fdnbSmCIbZjJaVtRl2KCgaGOQLqZpjVgWgo/5DUhKXZSJotTNG4ODr+IPuDhGzGabJh0mClmwTSIJPGZGKtOrJkwg4g2lKwnWxwbKU44o9ocmjxuz+eG/bscA7nx/OcPvTi/UpO7vu+7us+z/fKKZ9zcZ3nue9UFZKktvzGqAuQJA2f4S5JDTLcJalBhrskNchwl6QGLR11AQCnZHmdyumjLkOSXvPOveBXL+8//L3Jn1TVb03X7zUR7qdyOpdk46jLkKTXvPvvf+zl/SWrD/73TP1eE+EuSZqby8++sO/o4Iz9XHOXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDVo1nBPsiPJ0ST7prR/NMmTSfYn+Zu+9m1JDnXnLl+MoiVJr24uT2K6A/h74B9fakjyB8Am4IKqmkyyqms/D9gMnA+cDXwjyblV9eKwC5ckzWzWmXtVPQA8P6X5z4Bbq2qy63O0a98E3F1Vk1X1FHAIuHiI9UqS5mCha+7nAr+f5MEk/5rknV37GuCZvn4TXdsrJNmaZDzJ+DEmF1iGJGk6C31A9lJgBXAp8E5gV5I3A5mmb033DapqO7Ad4IysnLaPJGlhFjpznwDurZ6HgF8DZ3bt6/r6rQUOD1aiJGm+FhruXwHeB5DkXOAU4CfAbmBzkuVJ1gMbgIeGUagkae5mXZZJchdwGXBmkgngZmAHsKN7e+QLwJaqKmB/kl3A48Bx4HrfKSNJJ156mTxaZ2RlXZKNoy5Dkk4q36h7Hq6qsenO+QlVSWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDZg33JDuSHO2eujT13F8kqSRn9rVtS3IoyZNJLh92wZKk2c1l5n4HcMXUxiTrgA8AT/e1nQdsBs7vrrktyZKhVCpJmrNZw72qHgCen+bU3wGfAvqf07cJuLuqJqvqKeAQcPEwCpUkzd2C1tyTXAX8qKoem3JqDfBM3/FE1zbd99iaZDzJ+DEmF1KGJGkGS+d7QZLTgJuAP5zu9DRt0z6Bu6q2A9uh94Ds+dYhSZrZvMMd+B1gPfBYEoC1wCNJLqY3U1/X13ctcHjQIiVJ8zPvZZmq+n5Vraqqc6rqHHqB/o6q+jGwG9icZHmS9cAG4KGhVixJmtVc3gp5F/DvwFuSTCS5bqa+VbUf2AU8DnwNuL6qXhxWsZKkuZl1WaaqPjLL+XOmHN8C3DJYWZKkQfgJVUlqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkho0l4d17EhyNMm+vra/TfJEku8l+eckb+o7ty3JoSRPJrl8sQqXJM1sLjP3O4ArprTtAd5eVRcAPwC2ASQ5D9gMnN9dc1uSJUOrVpI0J7OGe1U9ADw/pe3rVXW8O/wOvQdhA2wC7q6qyap6CjgEXDzEeiVJczCMNfc/Af6l218DPNN3bqJre4UkW5OMJxk/xuQQypAkvWSgcE9yE3AcuPOlpmm61XTXVtX2qhqrqrFlLB+kDEnSFLM+IHsmSbYAHwY2VtVLAT4BrOvrthY4vPDyJEkLsaCZe5IrgL8ErqqqX/Wd2g1sTrI8yXpgA/DQ4GVKkuZj1pl7kruAy4Azk0wAN9N7d8xyYE8SgO9U1Z9W1f4ku4DH6S3XXF9VLy5W8ZKk6eX/VlRG54ysrEuycdRlSNJJ5Rt1z8NVNTbdOT+hKkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoNmDfckO5IcTbKvr21lkj1JDnbbFX3ntiU5lOTJJJcvVuGSpJnNZeZ+B3DFlLYbgb1VtQHY2x2T5DxgM3B+d81tSZYMrVpJ0pzMGu5V9QDw/JTmTcDObn8ncHVf+91VNVlVTwGHgIuHVKskaY4WuuZ+VlUdAei2q7r2NcAzff0mujZJ0gk06wOy5ynTtE37kNYkW4GtAKdy2pDLkKTXt4XO3J9Nshqg2x7t2ieAdX391gKHp/sGVbW9qsaqamwZyxdYhiRpOgsN993Alm5/C3BfX/vmJMuTrAc2AA8NVqIkab5mXZZJchdwGXBmkgngZuBWYFeS64CngWsAqmp/kl3A48Bx4PqqenGRapckzWDWcK+qj8xwauMM/W8BbhmkKEnSYPyEqiQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDRr2vWWkptx/+LGX9y8/+8IRViLNjzN3SWqQM3fpVThb18nKmbskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lq0EDhnuQTSfYn2ZfkriSnJlmZZE+Sg912xbCKlSTNzYLDPcka4GPAWFW9HVgCbAZuBPZW1QZgb3csSTqBBl2WWQq8IclS4DTgMLAJ2Nmd3wlcPeBrSJLmacHhXlU/Aj5N7wHZR4CfVdXXgbOq6kjX5wiwarrrk2xNMp5k/BiTCy1DkjSNQZZlVtCbpa8HzgZOT3LtXK+vqu1VNVZVY8tYvtAyJEnTGGRZ5v3AU1X1XFUdA+4F3g08m2Q1QLc9OniZkqT5GCTcnwYuTXJakgAbgQPAbmBL12cLcN9gJUqS5mvBd4WsqgeT3AM8AhwHHgW2A28EdiW5jt4vgGuGUagkae4GuuVvVd0M3DyleZLeLF6SNCJ+QlWSGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGDRTuSd6U5J4kTyQ5kORdSVYm2ZPkYLddMaxiJUlzM+jM/XPA16rqrcCF9B6zdyOwt6o2AHu7Y0nSCbTgcE9yBvBe4AsAVfVCVf0U2ATs7LrtBK4etEhJ0vwMMnN/M/Ac8MUkjya5PcnpwFlVdQSg264aQp2SpHkYJNyXAu8APl9VFwG/ZB5LMEm2JhlPMn6MyQHKkCRNNUi4TwATVfVgd3wPvbB/NslqgG57dLqLq2p7VY1V1dgylg9QhiRpqgWHe1X9GHgmyVu6po3A48BuYEvXtgW4b6AKJUnztnTA6z8K3JnkFOCHwB/T+4WxK8l1wNPANQO+hiRpngYK96r6LjA2zamNg3xfSdJg/ISqJDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBA4d7kiVJHk3y1e54ZZI9SQ522xWDlylJmo9hzNxvAA70Hd8I7K2qDcDe7liSdAINFO5J1gIfAm7va94E7Oz2dwJXD/IakqT5G3Tm/lngU8Cv+9rOqqojAN121XQXJtmaZDzJ+DEmByxDktRvweGe5MPA0ap6eCHXV9X2qhqrqrFlLF9oGZKkaSwd4Nr3AFcluRI4FTgjyZeAZ5OsrqojSVYDR4dRqCRp7hY8c6+qbVW1tqrOATYD36yqa4HdwJau2xbgvoGrlCTNy2K8z/1W4ANJDgIf6I4lSSfQIMsyL6uqbwPf7vb/B9g4jO8rSVoYP6EqSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwZ5huq6JN9KciDJ/iQ3dO0rk+xJcrDbrhheuZKkuRhk5n4c+GRVvQ24FLg+yXnAjcDeqtoA7O2OJUkn0CDPUD1SVY90+78ADgBrgE3Azq7bTuDqQYuUJM3PUNbck5wDXAQ8CJxVVUeg9wsAWDXDNVuTjCcZP8bkMMqQJHUGDvckbwS+DHy8qn4+1+uqantVjVXV2DKWD1qGJKnPQOGeZBm9YL+zqu7tmp9Nsro7vxo4OliJkqT5GuTdMgG+AByoqs/0ndoNbOn2twD3Lbw8SdJCLB3g2vcAfwR8P8l3u7a/Am4FdiW5DngauGawEiVJ87XgcK+qfwMyw+mNC/2+kqTB+QlVSWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDFi3ck1yR5Mkkh5LcuFivI0l6pUUJ9yRLgH8APgicB3wkyXmL8VqSpFdarJn7xcChqvphVb0A3A1smqnzuRf8ivsPP8b9hx9bpHIk6fVlkAdkv5o1wDN9xxPAJf0dkmwFtnaHk0tWH9zX2z24SCWN3JnAT0ZdxCJzjCe/1scHbY3xt2c6sVjhPt2Ds+v/HVRtB7YDJBmvqrFFquU1wTG2ofUxtj4+eH2MERZvWWYCWNd3vBY4vEivJUmaYrHC/T+ADUnWJzkF2AzsXqTXkiRNsSjLMlV1PMmfA/cDS4AdVbX/VS7Zvhh1vMY4xja0PsbWxwevjzGSqpq9lyTppOInVCWpQYa7JDVo5OHe2m0KkqxL8q0kB5LsT3JD174yyZ4kB7vtilHXOqgkS5I8muSr3XFTY0zypiT3JHmi+3m+q8ExfqL7d7ovyV1JTj3Zx5hkR5KjSfb1tc04piTbuvx5Msnlo6l6+EYa7o3epuA48MmqehtwKXB9N6Ybgb1VtQHY2x2f7G4ADvQdtzbGzwFfq6q3AhfSG2szY0yyBvgYMFZVb6f35ofNnPxjvAO4YkrbtGPq/tvcDJzfXXNbl0snvVHP3Od1m4KTQVUdqapHuv1f0AuENfTGtbPrthO4ejQVDkeStcCHgNv7mpsZY5IzgPcCXwCoqheq6qc0NMbOUuANSZYCp9H7PMpJPcaqegB4fkrzTGPaBNxdVZNV9RRwiF4unfRGHe7T3aZgzYhqGbok5wAXAQ8CZ1XVEej9AgBWja6yofgs8Cng131tLY3xzcBzwBe7pafbk5xOQ2Osqh8BnwaeBo4AP6uqr9PQGPvMNKZmM2jU4T7rbQpOVkneCHwZ+HhV/XzU9QxTkg8DR6vq4VHXsoiWAu8APl9VFwG/5ORbnnhV3brzJmA9cDZwepJrR1vVCddsBo063Ju8TUGSZfSC/c6qurdrfjbJ6u78auDoqOobgvcAVyX5L3pLae9L8iXaGuMEMFFVD3bH99AL+5bG+H7gqap6rqqOAfcC76atMb5kpjE1mUEw+nBv7jYFSUJvnfZAVX2m79RuYEu3vwW470TXNixVta2q1lbVOfR+Zt+sqmtpa4w/Bp5J8pauaSPwOA2Nkd5yzKVJTuv+3W6k9zeilsb4kpnGtBvYnGR5kvXABuChEdQ3fFU10i/gSuAHwH8CN426niGM5/fo/W/d94Dvdl9XAr9J76/0B7vtylHXOqTxXgZ8tdtvaozA7wLj3c/yK8CKBsf418ATwD7gn4DlJ/sYgbvo/Q3hGL2Z+XWvNibgpi5/ngQ+OOr6h/Xl7QckqUGjXpaRJC0Cw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ16H8BKZY1rOFCkN0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.pcolormesh(ds[\"__xarray_dataarray_variable__\"].values[9346])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10000, 178, 118)"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds[\"__xarray_dataarray_variable__\"].values.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
Increased min_filters in default benchmark to challenge GPUs more and show more of a separation between 1 and 8 GPUs.